### PR TITLE
Fixing a bug in the demo of chebspec,

### DIFF
--- a/chebspec_demo.m
+++ b/chebspec_demo.m
@@ -25,4 +25,4 @@ function C = chebspec_demo(N)
 % Report bugs/request features at https://github.com/eigtool/eigtool/issues
 
   C = gallery('chebspec',N);
-  C = C(1:end-1,1:end-1);
+  C = C(2:end,2:end);

--- a/private/set_demo_params.m
+++ b/private/set_demo_params.m
@@ -170,7 +170,7 @@ switch the_matrix
     routine = 'chebspec';
      if ~isnumeric(mtx_size),
       N = 20;
-      opts.ax = [-10 60 -40 40];
+      opts.ax = [-60 10 -40 40];
     end;
     if ~isnumeric(grid_size),
       if strcmp(grid_size,'F'),


### PR DESCRIPTION
as the right boundary condition corresponds to the left-most column of Matlab's Chebyshev differentiation matrix.
